### PR TITLE
created namespace for models

### DIFF
--- a/MCDA-APP/Forms/LoginForm.cs
+++ b/MCDA-APP/Forms/LoginForm.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 using System.Diagnostics;
 using System.Text;
 using System.Reflection;
-using Newtonsoft.Json;
+using MCDA_APP.Model;
 
 namespace MCDA_APP
 {
@@ -148,14 +148,4 @@ namespace MCDA_APP
             }
         }
     }
-
-    public class UserData
-    {
-        [JsonProperty("email")]
-        public string? Email { get; set; }
-
-        [JsonProperty("password")]
-        public string? Password { get; set; }
-    }
-
 }

--- a/MCDA-APP/Model/UserData.cs
+++ b/MCDA-APP/Model/UserData.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace MCDA_APP.Model
+{
+    internal class UserData
+    {
+        [JsonProperty("email")]
+        public string? Email { get; set; }
+
+        [JsonProperty("password")]
+        public string? Password { get; set; }
+    }
+}


### PR DESCRIPTION
Refactored LoginForm to follow c# conventions:
1. Methods and Controls should be named using PascalCase.
2. Moved class UserData to it's own Namespace name "Model", fixed Naming convention and added JSON annotations.
3. Removed unused Handlers.
4. Fixed TabIndex order of all controls. (order of selection using the TAB key).
5. Converted methods with a single line to expression-bodied methods.